### PR TITLE
Renamed Buttons to Button

### DIFF
--- a/spiketools/hub/spike.py
+++ b/spiketools/hub/spike.py
@@ -1638,7 +1638,7 @@ def greater_than(a, b):
     pass
 
 
-class Buttons:
+class Button:
     def __init__(self, location):
         """
         Accesses the PrimeHub buttons
@@ -1910,8 +1910,8 @@ class ColorSensor:
 class PrimeHub:
     speaker = Speaker()
     motion_sensor = MotionSensor()
-    left_button = Buttons("left")
-    right_button = Buttons("right")
+    left_button = Button("left")
+    right_button = Button("right")
     light_matrix = LightMatrix()
     status_light = StatusLight()
     PORT_A = 'A'


### PR DESCRIPTION
"from spike import Buttons" generates import error on the hub:
ImportError: no module named 'spike.Buttons'

Based on my testing it's supposed to be Button - with latest SPIKE prime firmware at least - although it somewhat contradicts with SPIKE app KB